### PR TITLE
feat: add expo doctor

### DIFF
--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -13,5 +13,7 @@ pre-push:
       run: yarn tsc --noEmit --pretty false
     dependencies_check:
       run: npx expo install --check
+    expo:
+      run: npx expo-doctor
     test_unit:
       run: yarn test:unit

--- a/app.config.ts
+++ b/app.config.ts
@@ -2,26 +2,7 @@ export default {
   expo: {
     name: 'Moxito',
     slug: 'moxito-fitness',
-    scheme: 'moxito',
     entryPoint: './app/index.tsx',
-    plugins: ['expo-font', 'expo-router', 'expo-secure-store', 'expo-web-browser'],
-    ios: {
-      bundleIdentifier: 'com.christianleovido.Moxito',
-      buildNumber: '2',
-      version: '1.1.0',
-      infoPlist: {
-        NSHealthShareUsageDescription:
-          'We need access to your health data to track your fitness progress',
-        NSHealthUpdateUsageDescription: 'We need permission to update your health data',
-      },
-      entitlements: {
-        'com.apple.developer.healthkit': true,
-        'com.apple.developer.healthkit.access': ['health-records'],
-      },
-    },
-    android: {
-      package: 'com.christianleovido.Moxito',
-    },
     updates: {
       url: 'https://u.expo.dev/d7541886-e8a9-47c0-84fc-0685f72d524d',
     },


### PR DESCRIPTION
## Summary
- strip `scheme`, `plugins`, and per-platform blocks from `app.config.ts` so the Expo config no longer fights the bare workflow; native identifiers now live solely in Xcode/Gradle
- extend the pre-push Lefthook to include `npx expo-doctor` alongside the existing Biome/TypeScript/dependency checks, ensuring native/project health is validated before pushing

## Testing
- npx expo-doctor
- yarn test:unit